### PR TITLE
fix: 修复 TypeScript 编译错误和发布工作流

### DIFF
--- a/.github/workflows/publish-schema-json-patch.yml
+++ b/.github/workflows/publish-schema-json-patch.yml
@@ -1,59 +1,76 @@
 name: Publish Schema JSON Patch
 
 on:
-  release:
-    types: [created]
+    release:
+        types: [created]
 
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Switch to main branch
-        run: |
-          git checkout main
-          git pull origin main
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
-      - name: Get release version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-      - name: Update package version
-        run: |
-          cd packages/schema-json-patch
-          npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
-      - name: Configure Git
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-      - name: Commit version update
-        run: |
-          git add packages/schema-json-patch/package.json
-          git commit -m "chore: update version to ${{ steps.get_version.outputs.VERSION }} [skip ci]"
-      - name: Push changes
-        run: git push origin main
-      - name: Clean
-        run: pnpm -F @waveox/schema-json-patch clean
-      - name: Build
-        run: pnpm build:package
-      - name: Test
-        run: pnpm -F @waveox/schema-json-patch test
-      - name: Check for d.ts files
-        run: find packages/schema-json-patch/dist -name "*.d.ts" | sort
-      - name: Publish schema-json-patch
-        run: cd packages/schema-json-patch && pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+    build-and-publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Switch to main branch
+              run: |
+                  git checkout main
+                  git pull origin main
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  registry-url: https://registry.npmjs.org/
+            - name: Install pnpm
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 8
+            - name: Install dependencies
+              run: pnpm install --no-frozen-lockfile
+            - name: Get release version
+              id: get_version
+              run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            - name: Check current version
+              id: check_version
+              run: |
+                  cd packages/schema-json-patch
+                  CURRENT_VERSION=$(node -p "require('./package.json').version")
+                  RELEASE_VERSION=${{ steps.get_version.outputs.VERSION }}
+                  if [ "$CURRENT_VERSION" = "$RELEASE_VERSION" ]; then
+                    echo "NEEDS_UPDATE=false" >> $GITHUB_OUTPUT
+                    echo "Version already up to date: $CURRENT_VERSION"
+                  else
+                    echo "NEEDS_UPDATE=true" >> $GITHUB_OUTPUT
+                    echo "Updating version from $CURRENT_VERSION to $RELEASE_VERSION"
+                  fi
+            - name: Update package version
+              if: steps.check_version.outputs.NEEDS_UPDATE == 'true'
+              run: |
+                  cd packages/schema-json-patch
+                  npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
+            - name: Configure Git
+              if: steps.check_version.outputs.NEEDS_UPDATE == 'true'
+              run: |
+                  git config --local user.email "github-actions[bot]@users.noreply.github.com"
+                  git config --local user.name "github-actions[bot]"
+            - name: Commit version update
+              if: steps.check_version.outputs.NEEDS_UPDATE == 'true'
+              run: |
+                  git add packages/schema-json-patch/package.json
+                  git commit -m "chore: update version to ${{ steps.get_version.outputs.VERSION }} [skip ci]"
+            - name: Push changes
+              if: steps.check_version.outputs.NEEDS_UPDATE == 'true'
+              run: git push origin main
+            - name: Clean
+              run: pnpm -F @waveox/schema-json-patch clean
+            - name: Build
+              run: pnpm build:package
+            - name: Test
+              run: pnpm -F @waveox/schema-json-patch test
+            - name: Check for d.ts files
+              run: find packages/schema-json-patch/dist -name "*.d.ts" | sort
+            - name: Publish schema-json-patch
+              run: cd packages/schema-json-patch && pnpm publish --access public --no-git-checks
+              env:
+                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/packages/schema-json-patch/package.json
+++ b/packages/schema-json-patch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waveox/schema-json-patch",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Patch libraries for handling fixed-structure JSON data, providing patch generation, conflict handling, and patch application capabilities",
     "type": "module",
     "main": "./dist/cjs/index.js",

--- a/packages/schema-json-patch/src/validatePatches.ts
+++ b/packages/schema-json-patch/src/validatePatches.ts
@@ -406,6 +406,10 @@ const pathExists = (
                 }
 
                 const pkField = schema.$item.$pk;
+                // 如果没有定义主键，无法通过主键查找
+                if (!pkField) {
+                    return false;
+                }
                 const item = current.find(
                     (i: unknown) =>
                         isObject(i) && (i as Record<string, unknown>)[pkField] === component


### PR DESCRIPTION
## v1.2.1

### Bug 修复
- 修复 `validatePatches.ts` 中的 TS2538 错误
  - 问题：$pk 字段可选，作为索引使用时可能为 undefined
  - 解决：在使用 `pkField` 前添加空值检查

### 工作流改进
- 优化发布工作流的版本更新逻辑
  - 新增：检查当前版本是否已与发布版本一致
  - 改进：仅在版本不同时才执行更新和提交
  - 效果：避免手动更新版本号后工作流报错